### PR TITLE
mktime() with no arguments should be time()

### DIFF
--- a/includes/classes/abstract_site_ui.php
+++ b/includes/classes/abstract_site_ui.php
@@ -27,7 +27,7 @@ class Site_UI {
     if (!$expire_date) { $expire_date = mktime(0,0,1,date('m'),date('d'),date('Y')); }
 
     // If no modified date, modified today
-    if (!$modified_date) { $modified_date = mktime(); }
+    if (!$modified_date) { $modified_date = time(); }
 
     header('Expires: '. gmdate('D, d M Y H:i:s', $expire_date ) .' GMT');
     header('Last-Modified: '. gmdate('D, d M Y H:i:s', $modified_date) .' GMT');

--- a/includes/classes/class_assessment.php
+++ b/includes/classes/class_assessment.php
@@ -277,7 +277,7 @@ class Assessment {
   * @return  string  ['pending','open','closed','finished']
   */
   function get_status() {
-    $now = mktime();
+    $now = time();
 
     $status = 'unknown';
     if ($this->open_date > $now) { $status = 'pending'; }

--- a/includes/classes/class_authenticator.php
+++ b/includes/classes/class_authenticator.php
@@ -106,7 +106,7 @@ class Authenticator {
         $user_module = $DAO->fetch_row($sql_user_module);
 
         // Update last login date
-        $now = date(MYSQL_DATETIME_FORMAT,mktime());
+        $now = date(MYSQL_DATETIME_FORMAT,time());
         $sql_login_date = 'UPDATE ' . APP__DB_TABLE_PREFIX . "user SET date_last_login = '{$now}' WHERE user_id = '{$user_data['user_id']}'";
         $DAO->execute($sql_login_date);
 

--- a/includes/classes/class_engcis.php
+++ b/includes/classes/class_engcis.php
@@ -522,7 +522,7 @@ class EngCIS {
       $years[] = dateToYear(strtotime($dates['first']));
       $years[] = dateToYear(strtotime($dates['last']));
     } else {
-      $years[] = dateToYear(mktime());
+      $years[] = dateToYear(time());
       $years[] = $years[0];
     }
 

--- a/includes/classes/class_group_collection.php
+++ b/includes/classes/class_group_collection.php
@@ -40,7 +40,7 @@ class GroupCollection {
   */
   function GroupCollection(&$DAO) {
     $this->_DAO =& $DAO;
-    $this->_created_on = mktime();
+    $this->_created_on = time();
     $this->_groups = null;
     $this->_group_objects = null;
     $this->_assessment_id = null;
@@ -201,7 +201,7 @@ class GroupCollection {
   * The locked_on datetime is IMMEDIATELY SAVED to the database (no other fields are saved)
   */
   function lock() {
-    $this->_locked_on = mktime();
+    $this->_locked_on = time();
     if ($this->id) {
       $_fields = array  (
                           'collection_locked_on'  => date(MYSQL_DATETIME_FORMAT,$this->_locked_on) ,

--- a/includes/classes/class_ui.php
+++ b/includes/classes/class_ui.php
@@ -125,7 +125,7 @@ class UI {
     if (!$expire_date) { $expire_date = mktime(0,0,1,date('m'),date('d'),date('Y')); }
 
     // If no modified date, modified today
-    if (!$modified_date) { $modified_date = mktime(); }
+    if (!$modified_date) { $modified_date = time(); }
 
     header('Expires: '. gmdate('D, d M Y H:i:s', $expire_date ) .' GMT');
     header('Last-Modified: '. gmdate('D, d M Y H:i:s', $modified_date) .' GMT');

--- a/includes/functions/lib_common.php
+++ b/includes/functions/lib_common.php
@@ -117,7 +117,7 @@ function logEvent($description, $module_id = NULL, $object_id = NULL) {
 
   global $DB;
 
-  $now = date(MYSQL_DATETIME_FORMAT,mktime());
+  $now = date(MYSQL_DATETIME_FORMAT,time());
   if (!empty($module_id)) {
     $module_id = intval($module_id);
   }

--- a/includes/functions/lib_university_functions.php
+++ b/includes/functions/lib_university_functions.php
@@ -22,7 +22,7 @@
 */
 function get_academic_year($date = null) {
   if (is_null($date)) {
-    $date = mktime();
+    $date = time();
   }
   $year = (int) date('Y',$date);
   $month = (int) date('n',$date);

--- a/students/assessments/index.php
+++ b/students/assessments/index.php
@@ -75,7 +75,7 @@ if ($assessments) {
     if ( (is_array($assessments_with_response)) && (in_array($assessment['assessment_id'], $assessments_with_response)) ) {
       $finished_assessments[] = $assessment;
     } else {
-      $now = mktime();
+      $now = time();
       $open_date = strtotime($assessment['open_date']);
       $close_date = strtotime($assessment['close_date']);
 
@@ -197,7 +197,7 @@ if ( (!$open_assessments) && (!$pending_assessments) && (!$finished_assessments)
     $status = 'finished';
     $status_capitalized = ucfirst($status);
 
-    $now = mktime();
+    $now = time();
 
     $assessment_iterator = new SimpleObjectIterator($finished_assessments, 'Assessment', '$DB');
     for ($assessment_iterator->reset(); $assessment_iterator->is_valid(); $assessment_iterator->next()) {

--- a/students/assessments/take/index.php
+++ b/students/assessments/take/index.php
@@ -117,7 +117,7 @@ if (($command) && ($assessment)) {
   switch ($command) {
     case 'save':
       // Check date/time of submission
-      $now = mktime();
+      $now = time();
       if ($now>$assessment->close_date) {
         $errors[] = 'You were too late in submitting your answers, the assessment is now closed.';
       } else {
@@ -226,7 +226,7 @@ if (($command) && ($assessment)) {
                                    'user_id'        =>  $_user->id,
                                    'marked_user_id'   =>  $id,
                                    'justification_text' =>  $justification_fetch,
-                                   'date_marked'      =>  date(MYSQL_DATETIME_FORMAT,mktime()),);
+                                   'date_marked'      =>  date(MYSQL_DATETIME_FORMAT,time()),);
                 }
               }
             }
@@ -239,7 +239,7 @@ if (($command) && ($assessment)) {
       // If there were no errors, save the changes
       if (!$errors) {
         // Save the results
-        $now = date(MYSQL_DATETIME_FORMAT,mktime());
+        $now = date(MYSQL_DATETIME_FORMAT,time());
 
         // Get IP and Computer name of the student saving the marks
         $ip_address = fetch_SERVER('REMOTE_ADDR','');
@@ -356,7 +356,7 @@ if (!$assessment) {
 ?>
   <form action="index.php?<?php echo($assessment_qs); ?>" method="post" name="assessment_form">
   <input type="hidden" name="command" value="none" />
-  <input type="hidden" name="date_opened" value="<?php echo(date(MYSQL_DATETIME_FORMAT,mktime())); ?>" />
+  <input type="hidden" name="date_opened" value="<?php echo(date(MYSQL_DATETIME_FORMAT,time())); ?>" />
 
   <div class="nav_button_bar">
     <table cellpadding="0" cellspacing="0" width="100%">

--- a/students/index.php
+++ b/students/index.php
@@ -74,7 +74,7 @@ if ($assessments) {
     if ( (is_array($assessments_with_response)) && (in_array($assessment['assessment_id'], $assessments_with_response)) ) {
       $finished_assessments[] = $assessment;
     } else {
-      $now = mktime();
+      $now = time();
       $open_date = strtotime($assessment['open_date']);
       $close_date = strtotime($assessment['close_date']);
 

--- a/tutors/assessments/create/class_wizardstep_1.php
+++ b/tutors/assessments/create/class_wizardstep_1.php
@@ -55,7 +55,7 @@ class WizardStep1 {
 
 
   function form() {
-    $today = mktime();
+    $today = time();
 
     $open_date = $this->wizard->get_field('open_date');
     if (is_null($open_date)) { $open_date = mktime(9, 0, 0); }  // default start time, today @ 9am
@@ -88,7 +88,7 @@ class WizardStep1 {
 
       // Draw year box
       echo("<td><select name=\"{$field_name}_year\">");
-      render_options_range(date('Y',mktime()), date('Y',mktime())+1, 1, date('Y', $selected_datetime));
+      render_options_range(date('Y',time()), date('Y',time())+1, 1, date('Y', $selected_datetime));
       echo('</select></td>');
 
       echo('<th>at</th>');

--- a/tutors/assessments/create/class_wizardstep_5.php
+++ b/tutors/assessments/create/class_wizardstep_5.php
@@ -46,7 +46,7 @@ class WizardStep5 {
     $DB =& $this->wizard->get_var('db');
     $config =& $this->wizard->get_var('config');
 
-    $now = mktime();
+    $now = time();
 
     require_once(DOC__ROOT . 'includes/classes/class_form.php');
     require_once(DOC__ROOT . 'includes/classes/class_group_handler.php');

--- a/tutors/assessments/edit/edit_assessment.php
+++ b/tutors/assessments/edit/edit_assessment.php
@@ -166,8 +166,8 @@ function render_datetime_boxes($field_name = 'datetime' , $selected_datetime) {
 
   // Draw year box
   echo("<td><select name=\"{$field_name}_year\">");
-  $year = (date('Y',mktime())<date('Y',$selected_datetime)) ? date('Y',mktime()) : date('Y',$selected_datetime) ;
-  render_options_range($year, date('Y',mktime())+1, 1, date('Y', $selected_datetime));
+  $year = (date('Y',time())<date('Y',$selected_datetime)) ? date('Y',time()) : date('Y',$selected_datetime) ;
+  render_options_range($year, date('Y',time())+1, 1, date('Y', $selected_datetime));
   echo('</select></td>');
 
   echo('<th>at</th>');

--- a/tutors/assessments/marks/mark_assessment.php
+++ b/tutors/assessments/marks/mark_assessment.php
@@ -114,7 +114,7 @@ if ( ($command) && ($assessment) ) {
         $xml_array['parameters']['grading']['_attributes'] = array ( 'value'  => $grading );
         $xml_array['parameters']['algorithm']['_attributes'] = array ( 'value'  => $algorithm );
 
-        $mysql_now = date(MYSQL_DATETIME_FORMAT,mktime());
+        $mysql_now = date(MYSQL_DATETIME_FORMAT,time());
 
         $fields = array (
           'assessment_id'     => $assessment_id ,


### PR DESCRIPTION
From the PHP manual on [mktime()](http://php.net/manual/en/function.mktime.php):

> As of PHP 5.1, when called with no arguments, **mktime()** throws an **E_STRICT** notice: use the [time()](http://php.net/manual/en/function.time.php): function instead.

This patch swaps out any call to `mktime()` without arguments for `time()` which prevents E_STRICT errors from occurring.