### PR TITLE
Added get_modules to a collection

### DIFF
--- a/includes/classes/class_group_collection.php
+++ b/includes/classes/class_group_collection.php
@@ -539,6 +539,15 @@ class GroupCollection {
 * --------------------------------------------------------------------------------
 */
 
+/**
+* Get the modules associated with this collection
+*
+* @return array  array ( module_id )
+*/
+function get_modules(){
+    return $this->_DAO->fetch_assoc("SELECT DISTINCT c.module_id FROM " . APP__DB_TABLE_PREFIX . "collection c");
+}
+
 /*
 * ================================================================================
 * Private Methods


### PR DESCRIPTION
There is a missing get_modules() on class_group_collection.php. This is called from a couple of places, including on uploading student data which includes groups. Fixed by adding this function.
